### PR TITLE
change: expect statement

### DIFF
--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -8,9 +8,7 @@ describe('query component', () => {
     test('successful query component', async () => {
         const result = renderWithClient(<Example />)
 
-        await waitFor(() => result.getByText(/name/))
-
-        expect(result.getByText(/name/)).toHaveTextContent('mocked-react-query')
+        expect(await result.findByText(/mocked-react-query/i)).toBeInTheDocument();
     })
 
     test('failure query component', async () => {
@@ -22,8 +20,6 @@ describe('query component', () => {
 
         const result = renderWithClient(<Example />)
 
-        await waitFor(() => result.getByText(/error/))
-
-        expect(result.getByText(/error/)).toHaveTextContent('An error has occurred')
+        expect(await result.findByText(/an error has occurred/i)).toBeInTheDocument();
     })
 })

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -8,7 +8,7 @@ describe('query component', () => {
     test('successful query component', async () => {
         const result = renderWithClient(<Example />)
 
-        expect(await result.findByText(/mocked-react-query/i)).toBeInTheDocument();
+        expect(await result.findByText(/mocked-react-query/i)).toBeInTheDocument()
     })
 
     test('failure query component', async () => {
@@ -20,6 +20,6 @@ describe('query component', () => {
 
         const result = renderWithClient(<Example />)
 
-        expect(await result.findByText(/an error has occurred/i)).toBeInTheDocument();
+        expect(await result.findByText(/an error has occurred/i)).toBeInTheDocument()
     })
 })


### PR DESCRIPTION
Using the .findByText with await is more in line with the React Testing Library examples.
It also cleans up the Act & Assert a bit more.